### PR TITLE
messageDummy spam downgraded to DEBUG

### DIFF
--- a/lib/DataRx.cpp
+++ b/lib/DataRx.cpp
@@ -233,8 +233,8 @@ void DataRx::rxPacket(const boost::system::error_code& ec,
     LOG(INFO) << std::string(_buffer->begin() + sizeof(OculusMessageHeader),
                              _buffer->end());
   } else {
-    LOG(WARNING) << "Ignoring " << MessageTypeToString(hdr.msgId())
-                 << " message, id " << static_cast<int>(hdr.msgId());
+    LOG(DEBUG) << "Ignoring " << MessageTypeToString(hdr.msgId())
+               << " message, id " << static_cast<int>(hdr.msgId());
   }
 
 exit:


### PR DESCRIPTION
@amarburg -- having this as a WARNING causes the oculus driver to spam the main raven launch window whenever the sonar isn't pinging.

Is there any reason not to downgrade the warning? I remember that there were reasons that made it hard to separate the totally-expected case from actual problems ...