### PR TITLE
fix: install headers and library (Aaron's version)

### DIFF
--- a/cmake/BuildNonROS.cmake
+++ b/cmake/BuildNonROS.cmake
@@ -122,3 +122,6 @@ install(
     DESTINATION share/oculus/cmake
     COMPONENT dev
 )
+
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION include/${PROJECT_NAME})

--- a/cmake/BuildNonROS.cmake
+++ b/cmake/BuildNonROS.cmake
@@ -125,3 +125,7 @@ install(
 
 install(DIRECTORY include/${PROJECT_NAME}/
     DESTINATION include/${PROJECT_NAME})
+
+install(TARGETS oculus
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/cmake/BuildNonROS.cmake
+++ b/cmake/BuildNonROS.cmake
@@ -123,9 +123,10 @@ install(
     COMPONENT dev
 )
 
-install(DIRECTORY include/${PROJECT_NAME}/
-    DESTINATION include/${PROJECT_NAME})
+install(DIRECTORY include/
+    TYPE INCLUDE
+)
 
 install(TARGETS oculus
-    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY
 )


### PR DESCRIPTION
Alternative version of #52 

@andresmanelli Since I'm not working with this library in a non-ROS2 context regularly, I'm not entirely sure on best practices for installing binaries.    I've modified your suggested PR slightly to use CMAKE defaults for both headers and libraries.   

I'm sure there are more sophisticated ways to handle it, but `make install` correctly installs everything in `/usr/local/...`     Curious if this works for your use case.